### PR TITLE
fix: Prevent overlay from appearing on initial page load

### DIFF
--- a/javascript.js
+++ b/javascript.js
@@ -1,4 +1,7 @@
 var overlay = document.getElementById('reroll-overlay');
+if (overlay) {
+  overlay.style.display = 'none';
+}
 
 function performRollLogic() {
   var randomNumber1 = Math.floor(Math.random() * 6) + 1;


### PR DESCRIPTION
The "Rerolling..." overlay was incorrectly displayed during the initial page load. This commit fixes the issue by explicitly setting the overlay's display style to 'none' at the beginning of the JavaScript execution.

This ensures the overlay is hidden by default and only appears when the "Roll Again" button is clicked, as intended.