### PR TITLE
feat: Implement initial game state with no auto-roll

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <body>
 
     <div class="container">
-      <h1>Refresh Me</h1>
+      <h1>To start the game, press the Roll Dice button</h1>
 
       <div class="dice-area">
         <div class="dice">
@@ -28,7 +28,7 @@
         </div>
       </div>
 
-      <button id="roll-button">Roll Again</button>
+      <button id="roll-button">Roll Dice</button>
     </div>
 
   <script src="javascript.js" charset="utf-8"></script>

--- a/javascript.js
+++ b/javascript.js
@@ -34,6 +34,12 @@ function handleRollButtonClick() {
 
   setTimeout(function() {
     performRollLogic();
+
+    // Change button text from "Roll Dice" to "Roll Again" after first roll
+    if (rollButton && rollButton.textContent === 'Roll Dice') {
+      rollButton.textContent = 'Roll Again';
+    }
+
     if (overlay) {
       overlay.style.display = 'none';
     }
@@ -46,4 +52,4 @@ if (rollButton) {
 }
 
 // Initial roll when the page loads
-rollDiceAndDeclareWinner();
+// rollDiceAndDeclareWinner();


### PR DESCRIPTION
This commit changes the initial behavior of the Dicee game:
- Dice no longer roll automatically on page load.
- The H1 title now initially displays: "To start the game, press the Roll Dice button".
- The button text initially is "Roll Dice".
- After the first successful roll, the button text changes to "Roll Again".

This provides a clearer starting point for you and makes the first dice roll an explicit action.