### PR TITLE
style: Revert overlay to be full-screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,16 +22,15 @@
           <p class="player-two-name">Player 2</p>
           <img class="img2" src="images/dice6.png">
         </div>
-
-        <div id="reroll-overlay">
-          <p>Rerolling...</p>
-        </div>
       </div>
 
       <button id="roll-button">Roll Dice</button>
     </div>
 
   <script src="javascript.js" charset="utf-8"></script>
+  <div id="reroll-overlay">
+    <p>Rerolling...</p>
+  </div>
   </body>
 
  

--- a/styles.css
+++ b/styles.css
@@ -41,7 +41,6 @@ footer {
 }
 
 .dice-area {
-  position: relative;
   display: inline-block;
 }
 
@@ -60,7 +59,7 @@ footer {
 
 #reroll-overlay {
   display: none; /* Hidden by default, JS changes to flex to show */
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
This commit changes the "Rerolling..." overlay to cover the entire screen again, as per your feedback.

Changes include:
- Modifying `styles.css` to set `#reroll-overlay` to `position: fixed` with dimensions to cover the viewport.
- Removing `position: relative` from `.dice-area` as it's no longer needed for overlay positioning.
- Moving the `#reroll-overlay` div in `index.html` to be a direct child of `<body>` for cleaner fixed positioning.

The overlay timing and game logic remain unaffected.