### PR TITLE
Make layout responsive for web and mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dicee</title>
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css?family=Indie+Flower|Lobster" rel="stylesheet">

--- a/styles.css
+++ b/styles.css
@@ -85,3 +85,17 @@ footer a:hover {
   font-family: 'Indie Flower', cursive;
   font-size: 3rem;
 }
+
+/* Media Query for smaller screens */
+@media (max-width: 768px) {
+  h1 {
+    font-size: 5rem; /* Reduced font size for smaller screens */
+  }
+  .container {
+    width: 90%; /* Increased width for smaller screens */
+  }
+  .dice {
+    display: block; /* Stack dice vertically */
+    margin: 0 auto 30px auto; /* Center block and add bottom margin */
+  }
+}


### PR DESCRIPTION
This commit introduces several changes to improve the responsiveness of the website:

1.  Added viewport meta tag to `index.html` for proper scaling on mobile devices.
2.  Adjusted `h1` font size from `8rem` to `5rem` on screens smaller than 768px to prevent overflow.
3.  Increased `.container` width from `70%` to `90%` on screens smaller than 768px to utilize more screen space.
4.  Modified `.dice` elements to `display: block` (stacked) with `margin: 0 auto 30px auto;` on screens smaller than 768px, changing from an inline-block (side-by-side) layout.

These changes ensure a better user experience across various device sizes.