### PR TITLE
Change footer hyperlink text color to white

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -50,7 +50,7 @@ footer {
 }
 
 footer a {
-  color: #4ECCA3; /* Link color same as h1 and p */
+  color: #FFFFFF; /* Changed link color to white */
   text-decoration: none; /* Remove underline */
 }
 


### PR DESCRIPTION
I've updated the CSS for the footer hyperlink (`footer a`) to set its text color to white (#FFFFFF). The existing text decoration (none) and hover effect have been maintained.